### PR TITLE
chore: fixing env variables to include OSSRH and GPG

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -34,6 +34,9 @@ on:
 jobs:
   Build-With-Maven:
     runs-on: ubuntu-latest
+    env:
+      MULE_EE_USERNAME: ${{ secrets.MULE_EE_USERNAME }}
+      MULE_EE_PASSWORD: ${{ secrets.MULE_EE_PASSWORD }}
     outputs:
       version: ${{ steps.set-version.outputs.version }}
 
@@ -51,8 +54,8 @@ jobs:
           java-version: ${{ inputs.java-version }}
           cache: maven
           server-id: mulesoft-ee-releases
-          server-username: ${{ secrets.MULE_EE_USERNAME }}
-          server-password: ${{ secrets.MULE_EE_PASSWORD }}
+          server-username: MULE_EE_USERNAME
+          server-password: MULE_EE_PASSWORD
 
       - name: Set up JDK for build and unit test
         uses: actions/setup-java@v3

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -43,7 +43,6 @@ jobs:
     env:
       OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
       MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
     steps:
       - uses: actions/checkout@v3
@@ -60,7 +59,7 @@ jobs:
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
-          gpg-private-key: MAVEN_GPG_PRIVATE_KEY
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase:  MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Maven Central

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -40,6 +40,11 @@ jobs:
     # Cannot use env.* variables here - https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     if: ${{ github.event_name != 'pull_request' && contains(github.ref,inputs.main-branch) }}
     runs-on: ubuntu-latest
+    env:
+      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -53,19 +58,15 @@ jobs:
           java-version: ${{ inputs.java-version }}
           cache: maven
           server-id: ossrh
-          server-username: ${{ secrets.OSSRH_USERNAME }}
-          server-password: ${{ secrets.OSSRH_PASSWORD }}
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase:  ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: MAVEN_GPG_PRIVATE_KEY
+          gpg-passphrase:  MAVEN_GPG_PASSPHRASE
 
       - name: Publish to Maven Central
         id: publish-to-maven-central
         if: ${{ inputs.publish-maven-central }}
         run: ./mvnw deploy -Drelease=true -DskipTests=true ${{ inputs.maven-args }}
-        env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
       - name: JReleaser full-Release
         uses: jreleaser/release-action@v2


### PR DESCRIPTION
Moved the setup-java secrets into 'env' variables.
Cleaned up other uses of step -> env vars (no longer needed, now that they are at the job level)