### PR TITLE
feat: support for maven deploy repositories

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -43,6 +43,8 @@ jobs:
     env:
       OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
       OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      MAVEN_PUBLISH_USERNAME: ${{ secrets.MAVEN_PUBLISH_USERNAME }}
+      MAVEN_PUBLISH_PASSWORD: ${{ secrets.MAVEN_PUBLISH_PASSWORD }}
       MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
     steps:
       - uses: actions/checkout@v3
@@ -61,6 +63,7 @@ jobs:
 
       - name: Set up JDK for maven central publish
         uses: actions/setup-java@v3
+        if: ${{ env.OSSRH_USERNAME != '' }}
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
@@ -68,6 +71,19 @@ jobs:
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase:  MAVEN_GPG_PASSPHRASE
+
+      - name: Set up JDK for maven deployment credentials
+        uses: actions/setup-java@v3
+        if: ${{ env.MAVEN_PUBLISH_USERNAME != '' }}
+        with:
+          distribution: ${{ inputs.java-distribution }}
+          java-version: ${{ inputs.java-version }}
+          cache: maven
+          server-id: maven-publish
+          server-username: MAVEN_PUBLISH_USERNAME
+          server-password: MAVEN_PUBLISH_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase:  MAVEN_GPG_PASSPHRASE
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,58 @@ Maven release workflow requires the following [Organization Secrets](https://git
 - JRELEASER_GPG_SECRET_KEY
 - MAVEN_GPG_PASSPHRASE
 - MAVEN_GPG_PRIVATE_KEY
-- OSSRH_PASSWORD
-- OSSRH_USERNAME
 - MULE_EE_PASSWORD (if Mule EE is needed)
 - MULE_EE_USERNAME (if Mule EE is needed)
+
+Depending on the target maven deployment repository, configure the target repository secrets and maven POM.
+
+**NOTE: Do not set both sets of secrets on a repository, build may fail.**
+
+If you are using [avio-mule-modules-parent](https://github.com/avioconsulting/avio-mule-modules-parent), check its documentation for how to configure Maven POM.
+
+#### Deploying to Maven Central
+
+Assign following secrets to the target repository -
+- OSSRH_PASSWORD
+- OSSRH_USERNAME
+
+Distribution Management section - 
+
+```xml
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>${nexus.url}/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>${nexus.url}/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+```
+
+### Deploying to AVIO's JFrog Artifactory
+
+Assign following Secrets to the target repository -
+- MAVEN_PUBLISH_USERNAME
+- MAVEN_PUBLISH_PASSWORD
+
+Distribution Management section -
+
+```xml
+  <distributionManagement>
+    <repository>
+      <id>maven-publish</id>
+      <name>AVIO Releases Repository</name>
+      <url>https://avio.jfrog.io/artifactory/mulesoft-mvn-local/</url>
+    </repository>
+    <snapshotRepository>
+      <id>maven-publish</id>
+      <name>AVIO Snapshots Repository</name>
+      <url>https://avio.jfrog.io/artifactory/mulesoft-mvn-local/</url>
+    </snapshotRepository>
+  </distributionManagement>
+```
 
 ### `maven-post-release.yml`
 


### PR DESCRIPTION
Support using a non-central maven deploy repositories. Usage of OSSRH can be migrated to these new secrets and setup but that will require migrating all plugins and libraries that are using OSSRH. Retaining it until that is done. See README updates for more details.