### PR TITLE
fix: use wildcard for surefire reports

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           files: |
             target/surefire-reports/*.xml
+            */target/surefire-reports/*.xml
 
       - name: Upload Build Artifacts (JARs and Maven Staging Repo)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
When running a multi-module project, pick up surefire-reports from all modules. 

The before result can be seen on this PR where module tests were not reports - https://github.com/avioconsulting/mule-opentelemetry-metrics-avio-provider/pull/22

The branch run with new fix can be seen on this PR - https://github.com/avioconsulting/mule-opentelemetry-metrics-avio-provider/pull/24

