### PR TITLE
ci(workflows): upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -68,4 +68,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -31,6 +31,9 @@ on:
         description: The application version
         value: ${{ jobs.Build-With-Gradle.outputs.version }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   Build-With-Gradle:
     runs-on: ubuntu-latest
@@ -38,12 +41,12 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           submodules: 'recursive'
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-post-release.yml
+++ b/.github/workflows/gradle-post-release.yml
@@ -35,6 +35,7 @@ on:
 env:
   is-check-into-main: ${{ github.event_name != 'pull_request' && github.ref == format('refs/head/{0}',inputs.main-branch) }}
   is-snapshot: ${{ contains(inputs.app-version, 'SNAPSHOT') }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Prepare-Next-Snapshot:
@@ -42,13 +43,13 @@ jobs:
     # Cannot use env.* variables here - https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     if: ${{ !contains(inputs.app-version, 'SNAPSHOT') && github.event_name != 'pull_request' && contains(github.ref, inputs.main-branch) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           submodules: 'recursive'
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -29,6 +29,7 @@ on:
 
 env:
   is-check-into-main: ${{ github.event_name != 'pull_request' && github.ref == format('refs/head/{0}',inputs.main-branch) }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Release:
@@ -36,13 +37,13 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && contains(github.ref, inputs.main-branch) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           submodules: 'recursive'
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
@@ -67,9 +68,11 @@ jobs:
           arguments: full-release
 
       - name: JReleaser release output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: jreleaser-release
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
+      

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -36,6 +36,10 @@ on:
       app-version:
         description: The application version
         value: ${{ jobs.Build-With-Maven.outputs.version }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   Build-With-Maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-post-release.yml
+++ b/.github/workflows/maven-post-release.yml
@@ -31,6 +31,7 @@ on:
 env:
   is-check-into-main: ${{ github.event_name != 'pull_request' && github.ref == format('refs/head/{0}',inputs.main-branch) }}
   is-snapshot: ${{ contains(inputs.app-version, 'SNAPSHOT') }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Prepare-Next-Snapshot:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -34,6 +34,7 @@ on:
         
 env:
   is-check-into-main: ${{ github.event_name != 'pull_request' && github.ref == format('refs/head/{0}',inputs.main-branch) }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   Release:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -17,6 +17,9 @@ on:
       app-version:
         description: The application version
         value: ${{ jobs.test.outputs.version }}
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: "Build and Publish artifacts"

--- a/.github/workflows/python-post-release.yml
+++ b/.github/workflows/python-post-release.yml
@@ -22,6 +22,8 @@ on:
         required: false
         type: string
         default: adesjardin, manikmagar, tannersherman
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   prepare-next-snapshot:

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -13,6 +13,9 @@ on:
         type: string
         default: main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     # Cannot use env.* variables here - https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability


### PR DESCRIPTION
- Update actions/checkout from v3 to v4
- Update actions/setup-java from v3 to v4
- Update actions/upload-artifact from v3 to v4
- Update actions/deploy-pages from v4 to v5
- Add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env var for Node 24 compatibility